### PR TITLE
use `Self` instead of enum_variant

### DIFF
--- a/parse-display-tests/tests/clippy_self.rs
+++ b/parse-display-tests/tests/clippy_self.rs
@@ -1,0 +1,12 @@
+#![deny(clippy::use_self)]
+
+use parse_display::*;
+
+#[test]
+fn clippy_use_self() {
+#[derive(FromStr)]
+enum Foo {
+    Bar,
+    Baz,
+}
+}


### PR DESCRIPTION
Without this the following warning would occur:

```
warning: unnecessary structure name repetition
 --> src/main.rs:7:6
  |
7 | enum Foo {
  |      ^^^ help: use the applicable keyword: `Self`
  |
```

and no clue on why this happens.