### PR TITLE
Update regex crate following cve-2022-24713

### DIFF
--- a/parse-display-derive/Cargo.toml
+++ b/parse-display-derive/Cargo.toml
@@ -18,7 +18,7 @@ proc-macro = true
 syn = { version = "1.0.68", features = ["visit"] }
 quote = "1.0.9"
 proc-macro2 = "1.0.26"
-regex = "1.4.5"
+regex = "1.5.5"
 regex-syntax = "0.6.23"
 once_cell = "1.7.2"
 structmeta = "0.1.4"

--- a/parse-display/Cargo.toml
+++ b/parse-display/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [dependencies]
 parse-display-derive = { version = "=0.5.4", path = "../parse-display-derive" }
 once_cell = { version = "1.7.2", optional = true }
-regex = { version = "1.4.5", optional = true }
+regex = { version = "1.5.5", optional = true }
 
 [features]
 default = ["std", "regex", "once_cell"]


### PR DESCRIPTION
Update the regex dependency to 1.5.5 which fixes [CVE-2022-24713](https://blog.rust-lang.org/2022/03/08/cve-2022-24713.html)