### PR TITLE
Use result with full path in the generated code

### DIFF
--- a/parse-display-derive/src/lib.rs
+++ b/parse-display-derive/src/lib.rs
@@ -440,7 +440,7 @@ impl<'a> ParserBuilder<'a> {
         let code = self.build_parse_code(constructor)?;
         Ok(quote! {
             #code
-            Err(parse_display::ParseError::new())
+            core::result::Result::Err(parse_display::ParseError::new())
         })
     }
     fn build_parse_variant_code(&self, constructor: Path) -> Result<ParseVariantCode> {
@@ -452,8 +452,8 @@ impl<'a> ParserBuilder<'a> {
                     let #fn_ident = |s: &str| -> core::result::Result<Self, parse_display::ParseError> {
                         #code
                     };
-                    if let Ok(value) = #fn_ident(s) {
-                        return Ok(value);
+                    if let core::result::Result::Ok(value) = #fn_ident(s) {
+                        return core::result::Result::Ok(value);
                     }
                 };
                 Ok(ParseVariantCode::Statement(code))
@@ -475,8 +475,8 @@ impl<'a> ParserBuilder<'a> {
                 code.extend(quote! { let #var = #expr; });
             }
             code.extend(quote! {
-                if let Ok(value) = ::parse_display::IntoResult::into_result(#new_expr) {
-                    return Ok(value);
+                if let core::result::Result::Ok(value) = ::parse_display::IntoResult::into_result(#new_expr) {
+                    return core::result::Result::Ok(value);
                 }
             });
             code
@@ -489,7 +489,7 @@ impl<'a> ParserBuilder<'a> {
             quote! {
                 let mut value = <Self as core::default::Default>::default();
                 #(#setters)*
-                return Ok(value);
+                return core::result::Result::Ok(value);
             }
         } else {
             let ps = match &self.source {
@@ -510,7 +510,7 @@ impl<'a> ParserBuilder<'a> {
                 }
                 Fields::Unit => quote! {},
             };
-            quote! { return Ok(#constructor #ps); }
+            quote! { return core::result::Result::Ok(#constructor #ps); }
         };
         Ok(code)
     }


### PR DESCRIPTION
Hello, I tried to learn `parse-display` today while playing with the advent of code and it wasn’t working with a strange error;
```rust
error[E0308]: mismatched types
   --> day2/src/bin/part2.rs:71:10
    |
71  | #[derive(FromStr, PartialEq, Debug, Clone, Copy)]
    |          ^^^^^^^
    |          |
    |          expected struct `ParseError`, found struct `aoc::Error`
    |          expected `Result<Match, ParseError>` because of return type
    |          in this derive macro expansion
    |
   ::: /Users/irevoire/.cargo/registry/src/github.com-1ecc6299db9ec823/parse-display-derive-0.6.0/src/lib.rs:151:1
    |
151 | pub fn derive_from_str(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
    | --------------------------------------------------------------------------------- in this expansion of `#[derive(FromStr)]`
    |
    = note: expected enum `Result<_, ParseError>`
               found enum `Result<_, aoc::Error>`
```

To me it look like the issues comes down to the fact that I re-exported a custom `Result` type, but actually no, when I do it explicitly I have no issue.


I don’t really know what generate this error but with this PR it’s fixed.

If you want to understand it better to be able to write a test here is how to reproduce it:
```
git clone https://github.com/irevoire/aoc2022.git
cd aoc2022/day2
sd 'use aoc::.*$' 'use aoc::*;' **/*.rs
cargo run --bin part2 smol
```