### PR TITLE
doc_auto_cfg was removed in favor of doc_cfg

### DIFF
--- a/parse-display/src/lib.rs
+++ b/parse-display/src/lib.rs
@@ -28,7 +28,7 @@
 //! assert_eq!("var_a".parse(), Ok(Y::VarA));
 //! ```
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "docs", feature(doc_auto_cfg))]
+#![cfg_attr(feature = "docs", feature(doc_cfg))]
 
 use core::convert::Infallible;
 use core::fmt::{Display, Formatter, Result};


### PR DESCRIPTION
See: https://github.com/rust-lang/rust/issues/43781

from: https://salsa.debian.org/rust-team/debcargo-conf/-/blob/master/src/parse-display/debian/patches/1.92-compat.patch?ref_type=heads

by @Fabian-Gruenbichler